### PR TITLE
Allow being provided a list of services to bound to the apps

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ resource "cloudfoundry_app" "prometheusmsteams" {
   }
 
   dynamic "service_binding" {
-    for_each = var.service_bindings
+    for_each = var.prometheusmsteams_service_bindings
 
     content {
       service_instance = service_binding.value.service_instance
@@ -60,7 +60,7 @@ resource "cloudfoundry_app" "alertmanager" {
   }
 
   dynamic "service_binding" {
-    for_each = var.service_bindings
+    for_each = var.alertmanager_service_bindings
 
     content {
       service_instance = service_binding.value.service_instance

--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,14 @@ resource "cloudfoundry_app" "prometheusmsteams" {
   routes {
     route = cloudfoundry_route.prometheusmsteams_internal[count.index].id
   }
+
+  dynamic "service_binding" {
+    for_each = var.service_bindings
+
+    content {
+      service_instance = service_binding.value.service_instance
+    }
+  }
 }
 
 resource "cloudfoundry_route" "prometheusmsteams_internal" {
@@ -48,6 +56,14 @@ resource "cloudfoundry_app" "alertmanager" {
     for_each = local.alertmanager_routes
     content {
       route = routes.value
+    }
+  }
+
+  dynamic "service_binding" {
+    for_each = var.service_bindings
+
+    content {
+      service_instance = service_binding.value.service_instance
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -52,12 +52,12 @@ variable "alertmanager" {
 
 variable "prometheusmsteams_service_bindings" {
   type        = list(object({ service_instance = string }))
-  description = "A list of service instances that should be bound to the apps"
+  description = "A list of service instances that should be bound to the prometheusmsteams"
   default     = []
 }
 
 variable "alertmanager_service_bindings" {
   type        = list(object({ service_instance = string }))
-  description = "A list of service instances that should be bound to the apps"
+  description = "A list of service instances that should be bound to the alertmanager"
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -50,7 +50,13 @@ variable "alertmanager" {
   default = {}
 }
 
-variable "service_bindings" {
+variable "prometheusmsteams_service_bindings" {
+  type        = list(object({ service_instance = string }))
+  description = "A list of service instances that should be bound to the apps"
+  default     = []
+}
+
+variable "alertmanager_service_bindings" {
   type        = list(object({ service_instance = string }))
   description = "A list of service instances that should be bound to the apps"
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -49,3 +49,9 @@ variable "alertmanager" {
   })
   default = {}
 }
+
+variable "service_bindings" {
+  type        = list(object({ service_instance = string }))
+  description = "A list of service instances that should be bound to the apps"
+  default     = []
+}


### PR DESCRIPTION
I'm adding a variable to be possible to provide a list of services to be bound to the apps. Such a feature is needed for example to send the apps logs to the log bucket. 